### PR TITLE
Update version file URL to current repo owner

### DIFF
--- a/SmartActuation.version
+++ b/SmartActuation.version
@@ -1,10 +1,10 @@
 {
   "NAME":"SmartActuation",
-  "URL":"https://raw.githubusercontent.com/theRagingIrishman/SmartActuation/master/SmartActuation.version",
-  "DOWNLOAD":"https://github.com/theRagingIrishman/SmartActuation/releases/latest",
+  "URL":"https://raw.githubusercontent.com/nagleaidan/SmartActuation/master/SmartActuation.version",
+  "DOWNLOAD":"https://github.com/nagleaidan/SmartActuation/releases/latest",
   "GITHUB":
   {
-    "USERNAME":"theRagingIrishman",
+    "USERNAME":"nagleaidan",
     "REPOSITORY":"SmartActuation",
     "ALLOW_PRE_RELEASE":false
   },


### PR DESCRIPTION
Hi @nagleaidan,

The URLs in this mod's version file are slightly out of date, they still have the previous repo owner. GitHub helpfully silently redirects them, so they still work, but this can sometimes trrigger GitHub's server-side rate limiting behavior.

Now they're updated to the latest correct values.